### PR TITLE
Iter with options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ install:
   - conda create -y -n test-env python=%PYTHON_VERSION%
   - conda -y install pip numpy pandas pytest
   - activate test-env
-  - python -m pip install -U .
+  - python -m pip install --no-deps -U .
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,8 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda update -y conda
   - conda create -y -n test-env python=%PYTHON_VERSION%
-  - conda install -y pip numpy pandas pytest
   - activate test-env
+  - conda install -y pip numpy pandas pytest
   - python -m pip install --no-deps -U .
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ install:
   
   # set up conda
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
-  - conda update conda
-  - conda create -n test-env python=%PYTHON_VERSION pip numpy pandas pytest
+  - conda update -y conda
+  - conda create -y -n test-env python=%PYTHON_VERSION pip numpy pandas pytest
   - activate test-env
   - python -m pip install -U .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,6 @@ install:
   - conda create -y -n test-env python=%PYTHON_VERSION%
   - activate test-env
   - conda install -y pip numpy pandas pytest
-  - python -m pip install --no-deps -U .
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,10 @@ install:
   - mecab -v
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python -V
-  - ps: python -m pip install pytest numpy pandas
-  - ps: python -m pip install -U . 
+  - python -m pip install -U pip
+  - python -m pip install setuptools
+  - python -m pip install pytest numpy pandas
+  - python -m pip install -U . 
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - mecab -v
   
   # set up conda
-  - set PATH="%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda update conda
   - conda create -n test-env python=%PYTHON_VERSION pip numpy pandas pytest
   - activate test-env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,30 +5,27 @@ environment:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
 
-    #- PYTHON: "C:\\Python26"
-    - PYTHON: "C:\\Python27"
-    #- PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36"
-    #- PYTHON: "C:\\Python26-x64"
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33-x64"
-    - PYTHON: "C:\\Python34-x64"
-    - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON_VERSION: 2.7
+      MINICONDA: "C:\\Miniconda"
+    - PYTHON_VERSION: 3.6
+      MINICONDA: "C:\\Miniconda3"
 
+init:
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
+  
 install:
+  # set up mecab
   - ps: tar -xvzf appveyor-ci/MeCab.tar.gz
   - ps: mv MeCab "C:\\Program Files"
   - set PATH=C:\\Program Files\MeCab\bin;%PATH%
   - mecab -v
-  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
-  - python -V
-  - python -m pip install -U pip
-  - python -m pip install setuptools
-  - python -m pip install pytest numpy pandas
-  - python -m pip install -U . 
+  
+  # set up conda
+  - set PATH="%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda update conda
+  - conda create -n test-env python=%PYTHON_VERSION pip numpy pandas pytest
+  - activate test-env
+  - python -m pip install -U .
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,4 +43,4 @@ install:
 build: off
 
 test_script:
-- py.test -v tests/
+  - py.test -v tests/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+# references
+# http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
+# https://github.com/appveyor/ci/issues/359
+
 environment:
 
   matrix:
@@ -23,7 +27,7 @@ install:
   # set up conda
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda update -y conda
-  - conda create -y -n test-env python=%PYTHON_VERSION pip numpy pandas pytest
+  - conda create -y -n test-env python=%PYTHON_VERSION% pip numpy pandas pytest
   - activate test-env
   - python -m pip install -U .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,18 @@ environment:
 
   matrix:
 
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
+    - PYTHON_VERSION: 2.6
+      MINICONDA: "C:\\Miniconda-x64"
+    - PYTHON_VERSION: 2.7
+      MINICONDA: "C:\\Miniconda-x64"
+    - PYTHON_VERSION: 3.3
+      MINICONDA: "C:\\Miniconda3-x64"
+    - PYTHON_VERSION: 3.4
+      MINICONDA: "C:\\Miniconda3-x64"
+    - PYTHON_VERSION: 3.5
+      MINICONDA: "C:\\Miniconda3-x64"
+    - PYTHON_VERSION: 3.6
+      MINICONDA: "C:\\Miniconda3-x64"
 
     - PYTHON_VERSION: 2.6
       MINICONDA: "C:\\Miniconda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,11 +35,12 @@ install:
   # set up conda
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda update -y conda
-  - conda create -y -n test-env python=%PYTHON_VERSION% pip numpy pandas pytest
+  - conda create -y -n test-env python=%PYTHON_VERSION%
+  - conda -y install pip numpy pandas pytest
   - activate test-env
   - python -m pip install -U .
 
 build: off
 
 test_script:
-- ps: pytest -v tests/
+- py.test -v tests/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,10 @@ install:
   - ps: mv MeCab "C:\\Program Files"
   - set PATH=C:\\Program Files\MeCab\bin;%PATH%
   - mecab -v
-  - ps: pip install pytest numpy pandas
-  - ps: pip install -U . 
+  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - python -V
+  - ps: python -m pip install pytest numpy pandas
+  - ps: python -m pip install -U . 
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python26-x64"
+    #- PYTHON: "C:\\Python26-x64"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda update -y conda
   - conda create -y -n test-env python=%PYTHON_VERSION%
-  - conda -y install pip numpy pandas pytest
+  - conda install -y pip numpy pandas pytest
   - activate test-env
   - python -m pip install --no-deps -U .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python26"
+    #- PYTHON: "C:\\Python26"
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
+    #- PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,16 @@ environment:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
 
+    - PYTHON_VERSION: 2.6
+      MINICONDA: "C:\\Miniconda"
     - PYTHON_VERSION: 2.7
       MINICONDA: "C:\\Miniconda"
+    - PYTHON_VERSION: 3.3
+      MINICONDA: "C:\\Miniconda3"
+    - PYTHON_VERSION: 3.4
+      MINICONDA: "C:\\Miniconda3"
+    - PYTHON_VERSION: 3.5
+      MINICONDA: "C:\\Miniconda3"
     - PYTHON_VERSION: 3.6
       MINICONDA: "C:\\Miniconda3"
 

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -169,6 +169,9 @@ def do_mecab_iter(x, *args, **kwargs):
                 if len(tmp) >= 3 and tmp[-3:] == 'EOS':
                     yield doc.decode(mecab_enc).strip()
                     doc = b''
+            if len(doc) > 0:
+                yield(doc)
+
     os.close(fd)
     os.remove(ofile)
 

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -60,8 +60,10 @@ def do_mecab(x, *args, **kwargs):
                isinstance(outpath, unicode) 
     else:
         print("do we have python 4 now?")
-            
-
+    
+    # convert args into bytes
+    args = (a.encode(mecab_enc) for a in args)
+    
     # conduct mecab if outfile is not None, 
     # then write it to the file;
     # otherwise do with no option

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -5,7 +5,8 @@ import sys
 import subprocess
 from tempfile import mkstemp
 from .config import get_mecab
-from .utils import mecab_exists, detect_mecab_enc, _no_mecab_message
+from .utils import mecab_exists, detect_mecab_enc
+from .utils import _no_mecab_message, get_mecab_opt
 
 
 # check the mecab command when imported
@@ -162,15 +163,18 @@ def do_mecab_iter(x, *args, **kwargs):
             for line in f:
                 yield line.decode(mecab_enc).strip()
         else:
+            EOS = get_mecab_opt('-E', *args)
+            EOS = 'EOS' if EOS is None else EOS.strip()
+
             doc = b''
             for line in f:
                 doc += line
                 tmp = line.decode(mecab_enc).strip()
-                if len(tmp) >= 3 and tmp[-3:] == 'EOS':
+                if tmp[(-len(EOS)):] == EOS:
                     yield doc.decode(mecab_enc).strip()
                     doc = b''
             if len(doc) > 0:
-                yield(doc)
+                yield(doc.decode(mecab_enc).strip())
 
     os.close(fd)
     os.remove(ofile)

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -61,9 +61,6 @@ def do_mecab(x, *args, **kwargs):
     else:
         print("do we have python 4 now?")
     
-    # convert args into bytes
-    args = (a.encode(mecab_enc) for a in args)
-    
     # conduct mecab if outfile is not None, 
     # then write it to the file;
     # otherwise do with no option

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -180,12 +180,12 @@ def do_mecab_iter(x, *args, **kwargs):
             for line in f:
                 tmp = line.decode(mecab_enc, 'ignore').strip()
                 if tmp[(-len(EOS_tmp)):] == EOS_tmp:
-                    tmp = tmp[0:len(EOS_tmp)] + EOS
-                    doc += u'\n' + tmp
+                    tmp = tmp[0:(-len(EOS_tmp))] + EOS
+                    doc += tmp
                     yield doc
                     doc = u''
                 else:
-                    doc += u'\n' + tmp
+                    doc += tmp + u'\n'
             if len(doc) > 0:
                 yield doc
 

--- a/mecabwrap/domecab.py
+++ b/mecabwrap/domecab.py
@@ -80,7 +80,7 @@ def do_mecab(x, *args, **kwargs):
     
     #p.terminate()
     
-    return out.decode(mecab_enc)
+    return out.decode(mecab_enc, 'ignore')
 
 
 def do_mecab_vec(x, *args, **kwargs):
@@ -160,7 +160,7 @@ def do_mecab_iter(x, *args, **kwargs):
     with open(ofile, 'rb') as f:
         if byline:
             for line in f:
-                yield line.decode(mecab_enc).strip()
+                yield line.decode(mecab_enc, 'ignore').strip()
         else:
             EOS = get_mecab_opt('-E', *args)
             EOS = 'EOS' if EOS is None else EOS.strip()
@@ -168,12 +168,12 @@ def do_mecab_iter(x, *args, **kwargs):
             doc = b''
             for line in f:
                 doc += line
-                tmp = line.decode(mecab_enc).strip()
+                tmp = line.decode(mecab_enc, 'ignore').strip()
                 if tmp[(-len(EOS)):] == EOS:
-                    yield doc.decode(mecab_enc).strip()
+                    yield doc.decode(mecab_enc, 'ignore').strip()
                     doc = b''
             if len(doc) > 0:
-                yield(doc.decode(mecab_enc).strip())
+                yield(doc.decode(mecab_enc, 'ignore').strip())
 
     os.close(fd)
     os.remove(ofile)

--- a/mecabwrap/utils.py
+++ b/mecabwrap/utils.py
@@ -37,19 +37,7 @@ def detect_mecab_enc(*args):
     """
     
     # get -d option if any
-    # note that mecab overwrites options given later
-    dopt = None
-    for i in range(len(args)):
-        a = args[i]
-        if a == '-d' or a == '--dicdir':
-            assert i + 1 < len(args)
-            dopt = args[i+1]
-        elif a[0:2] == '-d':         # -d option with no space
-            dopt = a[2:]
-        elif a[0:9] == '--dicdir=':  # --dicdir option with no space
-            dopt = a[9:]
-    if dopt is not None:
-        dopt = dopt.strip()
+    dopt = get_mecab_opt('-d', *args)
     
     assert mecab_exists(), "`%s` not found" % get_mecab()
     command = [get_mecab(), '-D']

--- a/mecabwrap/utils.py
+++ b/mecabwrap/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import sys
 import subprocess
 import re
 import argparse
@@ -55,33 +56,38 @@ def detect_mecab_enc(*args):
     
 
 # map short option name to long option name, type and store_true
+# set str type as unicode for python2
+_str_type = unicode if sys.version_info[0] == 2 else str
 _MECAB_OPTIONS = { 
-    '-r'  : ('--rcfile', str)
-    ,'-d' : ('--dicdir', str)
-    ,'-u' : ('--userdic', str)
+    '-r'  : ('--rcfile', _str_type)
+    ,'-d' : ('--dicdir', _str_type)
+    ,'-u' : ('--userdic', _str_type)
     ,'-l' : ('--lattice-level', int)
     ,'-D' : ('--dictionary-info', None)
-    ,'-O' : ('--output-format-type', str)
+    ,'-O' : ('--output-format-type', _str_type)
     ,'-a' : ('--all-morphs', None)
     ,'-N' : ('--nbest', int)
     ,'-p' : ('--partial', None)
     ,'-m' : ('--marginal', None)
     ,'-M' : ('--max-groupint-size', int)
-    ,'-F' : ('--node-format', str)
-    ,'-U' : ('--unk-format', str)
-    ,'-B' : ('--bos-format', str)
-    ,'-E' : ('--eos-format', str)
-    ,'-S' : ('--eon-format', str)
-    ,'-x' : ('--unk-feature', str)
+    ,'-F' : ('--node-format', _str_type)
+    ,'-U' : ('--unk-format', _str_type)
+    ,'-B' : ('--bos-format', _str_type)
+    ,'-E' : ('--eos-format', _str_type)
+    ,'-S' : ('--eon-format', _str_type)
+    ,'-x' : ('--unk-feature', _str_type)
     ,'-b' : ('--input-buffer-size', int)
     ,'-P' : ('--dump-config', None)
     ,'-C' : ('--allocate-sentence', None)
     ,'-t' : ('--theta', float)
     ,'-c' : ('--cost-factor', int)
-    ,'-o' : ('--output', str)
+    ,'-o' : ('--output', _str_type)
     ,'-v' : ('--version', None)
     #,'-h' : ('--help', None)
 }
+del(_str_type)
+
+
 _MECAB_ARG_PARSER = argparse.ArgumentParser()
 _MECAB_ARG_PARSER.add_argument('files', nargs='*')
 for short, item in _MECAB_OPTIONS.items():

--- a/notebook/usage.ipynb
+++ b/notebook/usage.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -180,17 +180,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "春(一般) | は(係助詞) | あけぼの(固有名詞) | EOS\n",
-      "やうやう(一般) | 白い(自立) | なる(自立) | ゆく(非自立) | 山際(一般) | EOS\n",
-      "少し(助詞類接続) | 明かり(一般) | て(格助詞) | EOS\n",
-      "紫(一般) | だ() | ちる(自立) | たり() | 雲(一般) | の(連体化) | 細い(自立) | たなびく(自立) | たり() | EOS\n",
+      "春(一般) | は(係助詞) | あけぼの(固有名詞) | ...ここまで\n",
+      "やうやう(一般) | 白い(自立) | なる(自立) | ゆく(非自立) | 山際(一般) | ...ここまで\n",
+      "少し(助詞類接続) | 明かり(一般) | て(格助詞) | ...ここまで\n",
+      "紫(一般) | だ() | ちる(自立) | たり() | 雲(一般) | の(連体化) | 細い(自立) | たなびく(自立) | たり() | ...ここまで\n",
       "\n"
      ]
     }
@@ -199,7 +199,7 @@
     "from mecabwrap import do_mecab_vec\n",
     "ins = ['春はあけぼの', 'やうやう白くなりゆく山際', '少し明かりて', '紫だちたる雲の細くたなびきたる']\n",
     "\n",
-    "out = do_mecab_vec(ins, '-F%f[6](%f[1]) | ')\n",
+    "out = do_mecab_vec(ins, '-F%f[6](%f[1]) | ', '-E...ここまで\\n')\n",
     "print(out)"
    ]
   },
@@ -210,36 +210,64 @@
     "### Returning Iterators\n",
     "\n",
     "When the number of input text is large, then holding the outcomes in the memory may not be a good idea.  `do_mecab_iter` function, which works for multiple texts, returns a generator of MeCab results.\n",
-    "When `byline=True`, each chunk is a line, which corresponds to a token in the default setting.\n",
-    "When `byline=False`, each chunk is a document, where a document is assumed to terminate with `'EOS'.`"
+    "When `byline=True`, chunks are separated by line breaks; a chunk corresponds to a token in the default setting.\n",
+    "When `byline=False`, chunks are separated by `EOS`; hence a chunk corresponds to a sentence."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "*** generating tokens ***\n",
+      "(1)\t春\t名詞,一般,*,*,*,*,春,ハル,ハル\n",
+      "(2)\tは\t助詞,係助詞,*,*,*,*,は,ハ,ワ\n",
+      "(3)\tあけぼの\t名詞,固有名詞,地域,一般,*,*,あけぼの,アケボノ,アケボノ\n",
+      "(4)\tEOS\n",
+      "(5)\tやうやう\t副詞,一般,*,*,*,*,やうやう,ヤウヤウ,ヨーヨー\n",
+      "(6)\t白く\t形容詞,自立,*,*,形容詞・アウオ段,連用テ接続,白い,シロク,シロク\n",
+      "(7)\tなり\t動詞,自立,*,*,五段・ラ行,連用形,なる,ナリ,ナリ\n",
+      "(8)\tゆく\t動詞,非自立,*,*,五段・カ行促音便ユク,基本形,ゆく,ユク,ユク\n",
+      "(9)\t山際\t名詞,一般,*,*,*,*,山際,ヤマギワ,ヤマギワ\n",
+      "(10)\tEOS\n",
+      "(11)\t少し\t副詞,助詞類接続,*,*,*,*,少し,スコシ,スコシ\n",
+      "(12)\t明かり\t名詞,一般,*,*,*,*,明かり,アカリ,アカリ\n",
+      "(13)\tて\t助詞,格助詞,連語,*,*,*,て,テ,テ\n",
+      "(14)\tEOS\n",
+      "(15)\t紫\t名詞,一般,*,*,*,*,紫,ムラサキ,ムラサキ\n",
+      "(16)\tだ\t助動詞,*,*,*,特殊・ダ,基本形,だ,ダ,ダ\n",
+      "(17)\tち\t動詞,自立,*,*,五段・ラ行,体言接続特殊２,ちる,チ,チ\n",
+      "(18)\tたる\t助動詞,*,*,*,文語・ナリ,体言接続,たり,タル,タル\n",
+      "(19)\t雲\t名詞,一般,*,*,*,*,雲,クモ,クモ\n",
+      "(20)\tの\t助詞,連体化,*,*,*,*,の,ノ,ノ\n",
+      "(21)\t細く\t形容詞,自立,*,*,形容詞・アウオ段,連用テ接続,細い,ホソク,ホソク\n",
+      "(22)\tたなびき\t動詞,自立,*,*,五段・カ行イ音便,連用形,たなびく,タナビキ,タナビキ\n",
+      "(23)\tたる\t助動詞,*,*,*,文語・ナリ,体言接続,たり,タル,タル\n",
+      "(24)\tEOS\n",
+      "\n",
+      "*** generating tokenized sentences ***\n",
       "---(1)\n",
       "春\t名詞,一般,*,*,*,*,春,ハル,ハル\n",
       "は\t助詞,係助詞,*,*,*,*,は,ハ,ワ\n",
       "あけぼの\t名詞,固有名詞,地域,一般,*,*,あけぼの,アケボノ,アケボノ\n",
-      "EOS\n",
+      "（文の終わり）\n",
       "---(2)\n",
       "やうやう\t副詞,一般,*,*,*,*,やうやう,ヤウヤウ,ヨーヨー\n",
       "白く\t形容詞,自立,*,*,形容詞・アウオ段,連用テ接続,白い,シロク,シロク\n",
       "なり\t動詞,自立,*,*,五段・ラ行,連用形,なる,ナリ,ナリ\n",
       "ゆく\t動詞,非自立,*,*,五段・カ行促音便ユク,基本形,ゆく,ユク,ユク\n",
       "山際\t名詞,一般,*,*,*,*,山際,ヤマギワ,ヤマギワ\n",
-      "EOS\n",
+      "（文の終わり）\n",
       "---(3)\n",
       "少し\t副詞,助詞類接続,*,*,*,*,少し,スコシ,スコシ\n",
       "明かり\t名詞,一般,*,*,*,*,明かり,アカリ,アカリ\n",
       "て\t助詞,格助詞,連語,*,*,*,て,テ,テ\n",
-      "EOS\n",
+      "（文の終わり）\n",
       "---(4)\n",
       "紫\t名詞,一般,*,*,*,*,紫,ムラサキ,ムラサキ\n",
       "だ\t助動詞,*,*,*,特殊・ダ,基本形,だ,ダ,ダ\n",
@@ -250,7 +278,7 @@
       "細く\t形容詞,自立,*,*,形容詞・アウオ段,連用テ接続,細い,ホソク,ホソク\n",
       "たなびき\t動詞,自立,*,*,五段・カ行イ音便,連用形,たなびく,タナビキ,タナビキ\n",
       "たる\t助動詞,*,*,*,文語・ナリ,体言接続,たり,タル,タル\n",
-      "EOS\n"
+      "（文の終わり）\n"
      ]
     }
    ],
@@ -259,8 +287,15 @@
     "\n",
     "ins = ['春はあけぼの', 'やうやう白くなりゆく山際', '少し明かりて', '紫だちたる雲の細くたなびきたる']\n",
     "\n",
+    "print('\\n*** generating tokens ***')\n",
     "i = 0\n",
-    "for text in do_mecab_iter(ins, byline=False):\n",
+    "for text in do_mecab_iter(ins, byline=True):\n",
+    "    i += 1\n",
+    "    print('(' + str(i) + ')\\t' + text)\n",
+    "    \n",
+    "print('\\n*** generating tokenized sentences ***')\n",
+    "i = 0\n",
+    "for text in do_mecab_iter(ins, '-E', '（文の終わり）', byline=False):\n",
     "    i += 1\n",
     "    print('---(' + str(i) + ')\\n' + text)"
    ]
@@ -276,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -309,7 +344,7 @@
        "False"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -393,13 +428,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "charset:\tUTF-8\n",
+      "\n",
       "日本\t名詞,固有名詞,地域,国,*,*,日本,ニッポン,ニッポン\n",
       "列島\t名詞,一般,*,*,*,*,列島,レットウ,レットー\n",
       "改造\t名詞,サ変接続,*,*,*,*,改造,カイゾウ,カイゾー\n",
@@ -416,6 +453,10 @@
     }
    ],
    "source": [
+    "# show mecab dict\n",
+    "! mecab -D | grep charset\n",
+    "print()\n",
+    "\n",
     "o1 = do_mecab('日本列島改造論', mecab_enc=None)      # default\n",
     "print(o1)\n",
     "\n",

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -76,6 +76,17 @@ class TestDomecabIter(unittest.TestCase):
             self.assertEqual(line[-4:], u'おしまい')
         self.assertEqual(ct, 2)
         
+        ct = 0
+        for line in do_mecab_iter(ins, u'--eos-format=おしまい\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-4:], u'おしまい')
+        self.assertEqual(ct, 2)
+
+        ct = 0
+        for line in do_mecab_iter(ins, u'--eos-format', 'おしまい\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-4:], u'おしまい')
+        self.assertEqual(ct, 2)
 
         
 class TestMultipleOptions(unittest.TestCase):

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -83,7 +83,7 @@ class TestDomecabIter(unittest.TestCase):
         self.assertEqual(ct, 2)
 
         ct = 0
-        for line in do_mecab_iter(ins, u'--eos-format', 'おしまい\n', byline=False):
+        for line in do_mecab_iter(ins, '--eos-format', u'おしまい\n', byline=False):
             ct += 1 
             self.assertEqual(line[-4:], u'おしまい')
         self.assertEqual(ct, 2)

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -61,8 +61,34 @@ class TestDomecabIter(unittest.TestCase):
         for line in do_mecab_iter(ins, '-Owakati', byline=False):
             ct += 1 
         self.assertEqual(ct, 1)
+
+    def test_iter_Eopt(self):
+        ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
+        ct = 0
+        for line in do_mecab_iter(ins, u'-EEND\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-3:], u'END')
+        self.assertEqual(ct, 2)
+
+        ct = 0
+        for line in do_mecab_iter(ins, '-E', u'END\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-3:], u'END')
+        self.assertEqual(ct, 2)
+        
+        ct = 0
+        for line in do_mecab_iter(ins, u'--eos-format=END\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-3:], u'END')
+        self.assertEqual(ct, 2)
+
+        ct = 0
+        for line in do_mecab_iter(ins, '--eos-format', u'END\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-3:], u'END')
+        self.assertEqual(ct, 2)
     
-    def test_iter_Eoption(self):
+    def test_iter_Eopt_unicode(self):
         ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
         ct = 0
         for line in do_mecab_iter(ins, u'-Eおしまい\n', byline=False):

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -4,6 +4,7 @@
 import unittest
 import re
 import codecs
+import types
 from mecabwrap.domecab import do_mecab, do_mecab_vec, do_mecab_iter
 from mecabwrap.utils import detect_mecab_enc
 
@@ -51,7 +52,21 @@ class TestDomecabVec(unittest.TestCase):
 
 
 class TestDomecabIter(unittest.TestCase):
+
     def test_iter(self):
+        ins = [u'アイスコーヒー', u'飲みたい']
+        it = do_mecab_iter(ins, '-F%m\n', byline=True)
+        self.assertTrue(isinstance(it, types.GeneratorType))
+        self.assertEqual(
+            list(it), [u'アイス', u'コーヒー', u'EOS', u'飲み', u'たい', u'EOS'])
+
+        ins = [u'ぶどうパン', u'食べたい']
+        it = do_mecab_iter(ins, '-F%m\n', byline=False)
+        self.assertTrue(isinstance(it, types.GeneratorType))
+        self.assertEqual(
+            list(it), [u'ぶどう\nパン\nEOS', u'食べ\nたい\nEOS'])
+            
+    def test_iter_count(self):
         ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
         ct = 0
         for line in do_mecab_iter(ins, byline=False):
@@ -73,25 +88,25 @@ class TestDomecabIter(unittest.TestCase):
         ct = 0
         for line in do_mecab_iter(ins, '-EEND\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], 'END')
+            self.assertEqual(line[-4:], '\nEND')
         self.assertEqual(ct, 2)
 
         ct = 0
         for line in do_mecab_iter(ins, '-E', 'END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], 'END')
+            self.assertEqual(line[-4:], '\nEND')
         self.assertEqual(ct, 2)
         
         ct = 0
         for line in do_mecab_iter(ins, '--eos-format=END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], 'END')
+            self.assertEqual(line[-4:], '\nEND')
         self.assertEqual(ct, 2)
 
         ct = 0
         for line in do_mecab_iter(ins, '--eos-format', 'END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], 'END')
+            self.assertEqual(line[-4:], '\nEND')
         self.assertEqual(ct, 2)
     
     def test_iter_Eopt_unicode(self):    
@@ -99,25 +114,25 @@ class TestDomecabIter(unittest.TestCase):
         ct = 0
         for line in do_mecab_iter(ins, u'-Eおしまい\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-4:], u'おしまい')
+            self.assertEqual(line[-5:], u'\nおしまい')
         self.assertEqual(ct, 2)
 
         ct = 0
         for line in do_mecab_iter(ins, '-E', u'おしまい\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-4:], u'おしまい')
+            self.assertEqual(line[-5:], u'\nおしまい')
         self.assertEqual(ct, 2)
         
         ct = 0
         for line in do_mecab_iter(ins, u'--eos-format=おしまい\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-4:], u'おしまい')
+            self.assertEqual(line[-5:], u'\nおしまい')
         self.assertEqual(ct, 2)
 
         ct = 0
         for line in do_mecab_iter(ins, '--eos-format', u'おしまい\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-4:], u'おしまい')
+            self.assertEqual(line[-5:], u'\nおしまい')
         self.assertEqual(ct, 2)
 
         

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -94,12 +94,7 @@ class TestDomecabIter(unittest.TestCase):
             self.assertEqual(line[-3:], 'END')
         self.assertEqual(ct, 2)
     
-    def test_iter_Eopt_unicode(self):
-        # skip this test if encoding is not utf8
-        # even mecab application does not get this right
-        if codecs.lookup(detect_mecab_enc()).name != 'utf8':
-            return
-    
+    def test_iter_Eopt_unicode(self):    
         ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
         ct = 0
         for line in do_mecab_iter(ins, u'-Eおしまい\n', byline=False):

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -56,9 +56,12 @@ class TestDomecabIter(unittest.TestCase):
         for line in do_mecab_iter(ins, '-Owakati', byline=True):
             ct += 1 
         self.assertEqual(ct, 2)
-
-
-
+        
+        ct = 0
+        for line in do_mecab_iter(ins, '-Owakati', byline=False):
+            ct += 1 
+        self.assertEqual(ct, 1)
+        
 class TestMultipleOptions(unittest.TestCase):
     def test_multiple_options(self):
         out = do_mecab(u"すもももももももものうち", '-Bbegin\n', '-Eend\n')

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -61,6 +61,22 @@ class TestDomecabIter(unittest.TestCase):
         for line in do_mecab_iter(ins, '-Owakati', byline=False):
             ct += 1 
         self.assertEqual(ct, 1)
+    
+    def test_iter_Eoption(self):
+        ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
+        ct = 0
+        for line in do_mecab_iter(ins, u'-Eおしまい\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-4:], u'おしまい')
+        self.assertEqual(ct, 2)
+
+        ct = 0
+        for line in do_mecab_iter(ins, '-E', u'おしまい\n', byline=False):
+            ct += 1 
+            self.assertEqual(line[-4:], u'おしまい')
+        self.assertEqual(ct, 2)
+        
+
         
 class TestMultipleOptions(unittest.TestCase):
     def test_multiple_options(self):

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -65,27 +65,27 @@ class TestDomecabIter(unittest.TestCase):
     def test_iter_Eopt(self):
         ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
         ct = 0
-        for line in do_mecab_iter(ins, u'-EEND\n', byline=False):
+        for line in do_mecab_iter(ins, '-EEND\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], u'END')
+            self.assertEqual(line[-3:], 'END')
         self.assertEqual(ct, 2)
 
         ct = 0
-        for line in do_mecab_iter(ins, '-E', u'END\n', byline=False):
+        for line in do_mecab_iter(ins, '-E', 'END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], u'END')
+            self.assertEqual(line[-3:], 'END')
         self.assertEqual(ct, 2)
         
         ct = 0
-        for line in do_mecab_iter(ins, u'--eos-format=END\n', byline=False):
+        for line in do_mecab_iter(ins, '--eos-format=END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], u'END')
+            self.assertEqual(line[-3:], 'END')
         self.assertEqual(ct, 2)
 
         ct = 0
-        for line in do_mecab_iter(ins, '--eos-format', u'END\n', byline=False):
+        for line in do_mecab_iter(ins, '--eos-format', 'END\n', byline=False):
             ct += 1 
-            self.assertEqual(line[-3:], u'END')
+            self.assertEqual(line[-3:], 'END')
         self.assertEqual(ct, 2)
     
     def test_iter_Eopt_unicode(self):

--- a/tests/test_domecab.py
+++ b/tests/test_domecab.py
@@ -3,9 +3,9 @@
 
 import unittest
 import re
-from mecabwrap.domecab import do_mecab
-from mecabwrap.domecab import do_mecab_vec
-from mecabwrap.domecab import do_mecab_iter
+import codecs
+from mecabwrap.domecab import do_mecab, do_mecab_vec, do_mecab_iter
+from mecabwrap.utils import detect_mecab_enc
 
 
 class TestDomecab(unittest.TestCase):
@@ -21,7 +21,13 @@ class TestDomecab(unittest.TestCase):
         words = re.findall(r'[^\t\n]+\t', out)
         words = [w[:-1] for w in words]
         self.assertEqual(words, [u'メロン', u'パン', u'を', u'食べる'])
-
+    
+    def test_unicode(self):
+        out = do_mecab(u'メロンパンを食べる', '-E', u'おわり\n', '-B', u'はじまり\n')
+        words = re.findall(r'[^\t\n]+\t', out[1:-1])
+        words = [w[:-1] for w in words]
+        self.assertEqual(words, [u'メロン', u'パン', u'を', u'食べる'])
+        
 
 class TestDomecabVec(unittest.TestCase):
     def test_vec(self):
@@ -89,6 +95,11 @@ class TestDomecabIter(unittest.TestCase):
         self.assertEqual(ct, 2)
     
     def test_iter_Eopt_unicode(self):
+        # skip this test if encoding is not utf8
+        # even mecab application does not get this right
+        if codecs.lookup(detect_mecab_enc()).name != 'utf8':
+            return
+    
         ins = [u'となりの客はよく柿食う客だ', u'バスガス爆発']
         ct = 0
         for line in do_mecab_iter(ins, u'-Eおしまい\n', byline=False):

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from mecabwrap.utils import *
+
+
+class TestMecabOption(unittest.TestCase):
+    def test_opt(self):
+        args = ['-d', 'foo', 
+                '--output-format-type=wakati', 
+                '--eos-format', 'END',
+                '-p', '--dump-config']  
+
+        ret = get_mecab_opt('-d', *args)
+        self.assertEqual(ret, 'foo')
+        ret = get_mecab_opt('--dicdir', *args)
+        self.assertEqual(ret, 'foo')
+
+        ret = get_mecab_opt('-O', *args)
+        self.assertEqual(ret, 'wakati')
+        ret = get_mecab_opt('--output-format-type', *args)
+        self.assertEqual(ret, 'wakati')
+
+        ret = get_mecab_opt('-E', *args)
+        self.assertEqual(ret, 'END')
+        ret = get_mecab_opt('--eos-format', *args)
+        self.assertEqual(ret, 'END')
+
+        ret = get_mecab_opt('-N', *args)
+        self.assertTrue(ret is None)
+        ret = get_mecab_opt('--nbest', *args)
+        self.assertTrue(ret is None)
+
+        ret = get_mecab_opt('-t', *args)
+        self.assertTrue(ret is None)
+        ret = get_mecab_opt('--theta', *args)
+        self.assertTrue(ret is None)
+
+        ret = get_mecab_opt('-p', *args)
+        self.assertTrue(ret)
+        ret = get_mecab_opt('--partial', *args)
+        self.assertTrue(ret)
+
+        ret = get_mecab_opt('-P', *args)
+        self.assertTrue(ret)
+        ret = get_mecab_opt('--dump-config', *args)
+        self.assertTrue(ret)
+
+        ret = get_mecab_opt('-m', *args)
+        self.assertFalse(ret)
+        ret = get_mecab_opt('--marginal', *args)
+        self.assertFalse(ret)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -53,5 +53,14 @@ class TestMecabOption(unittest.TestCase):
         self.assertFalse(ret)
 
 
+    def test_unicode(self):
+        args = ['-E', u'終わりです！']
+        ret = get_mecab_opt('-E', *args)
+        self.assertEqual(ret, u'終わりです！')
+        
+        ret = get_mecab_opt('--eos-format', *args)
+        self.assertEqual(ret, u'終わりです！')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* fix `do_mecab_iter` to work with `-E` option, which addresses #29, #30
* test on appveyor with Miniconda
* solve unicode error when mecab args includes unicode strings